### PR TITLE
Fix term-attrs members for musl.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.o
 *.import.scm
 *.link
+stty-config.scm

--- a/build-stty-config
+++ b/build-stty-config
@@ -1,0 +1,20 @@
+#!/bin/sh
+CC="${CC:-cc}"
+trap 'rm -f conftest.c conftest.o' exit
+
+exec > stty-config.scm
+printf "(import (chicken platform))\n"
+
+cat > conftest.c <<'EOF'
+#include <termios.h>
+void foo(struct termios *t) {
+	t->c_ospeed = 300;
+}
+EOF
+
+"${CC}" -c -o conftest.o conftest.c > /dev/null 2>&1
+if [ "$?" -eq 0 ] ; then
+  printf "(register-feature! 'HAVE_TERMIOS_SPEED_MEMBERS)\n"
+else
+  printf "(unregister-feature! 'HAVE_TERMIOS_SPEED_MEMBERS)\n"
+fi

--- a/stty.egg
+++ b/stty.egg
@@ -6,10 +6,13 @@
  (synopsis "stty-style interface to termios")
  (license "BSD")
  (category io)
- (components  (extension stty))
- (component-options
-   (csc-options "-O3" "-d1"))
- (dependencies foreigners srfi-69)
+ (components (generated-source-file stty-config
+               (custom-build "build-stty-config"))
+   (extension stty
+     (source "stty.scm")
+     (component-dependencies stty-config)
+     (csc-options "-X" "stty-config.scm" "-X" "feature-test-syntax" "-O3" "-d1")))
+ (dependencies feature-test foreigners srfi-69)
  (author "Alex Shinn")
  (maintainer "Erik Falor")
 )

--- a/stty.scm
+++ b/stty.scm
@@ -76,8 +76,6 @@
   term-attrs-cflag term-attrs-cflag-set!
   term-attrs-lflag term-attrs-lflag-set!
   term-attrs-cc term-attrs-cc-set!
-  term-attrs-ispeed term-attrs-ispeed-set!
-  term-attrs-ospeed term-attrs-ospeed-set!
   TCSANOW TCSADRAIN TCSAFLUSH)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -94,7 +92,13 @@
       (chicken file posix)
       (chicken fixnum)
       (chicken foreign)
+      (chicken module)
       foreigners)))
+
+#+HAVE_TERMIOS_SPEED_MEMBERS
+  (export
+    term-attrs-ispeed term-attrs-ispeed-set!
+    term-attrs-ospeed term-attrs-ospeed-set!)
 
 (declare (foreign-declare "#include <termios.h>\n"))
 (declare (foreign-declare "typedef struct termios struct_termios;\n"))
@@ -107,7 +111,9 @@
   (unsigned-long c_cflag term-attrs-cflag term-attrs-cflag-set!)
   (unsigned-long c_lflag term-attrs-lflag term-attrs-lflag-set!)
   (unsigned-char (c_cc 22) term-attrs-cc term-attrs-cc-set!)
+  #+HAVE_TERMIOS_SPEED_MEMBERS
   (unsigned-long c_ispeed term-attrs-ispeed term-attrs-ispeed-set!)
+  #+HAVE_TERMIOS_SPEED_MEMBERS
   (unsigned-long c_ospeed term-attrs-ospeed term-attrs-ospeed-set!)
   )
 


### PR DESCRIPTION
musl's struct termios doesn't have c_ispeed and c_ospeed members.
Check for them at compile time and don't add them to the foreign record
declaration if they don't exist.
